### PR TITLE
Add simple AMFE HTML page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # BarackV2
-Barack con mas exp
+
+Esta versión incluye una vista sencilla de AMFE.
+
+## Uso
+
+1. Abre `amfe.html` en un navegador.
+2. La página leerá los datos almacenados en `localStorage` bajo la clave `amfe`.
+3. Se mostrará un spinner mientras se cargan los datos.
+4. La tabla resultante es solo de lectura y puede refrescarse con el botón **Refrescar**.
+
+Los datos deben estar almacenados como un array de objetos JSON. Ejemplo:
+```javascript
+localStorage.setItem('amfe', JSON.stringify([
+  {"ID":1,"Item":"pieza","ModoFalla":"rotura"},
+  {"ID":2,"Item":"pieza2","ModoFalla":"desgaste"}
+]));
+```

--- a/amfe.html
+++ b/amfe.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>AMFE</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>AMFE</h1>
+<button id="refresh">Refrescar</button>
+<div id="loading">Cargando...</div>
+<div id="amfe" class="table-container"></div>
+<script src="js/dataService.js"></script>
+<script src="js/views/amfe.js"></script>
+</body>
+</html>

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -1,0 +1,13 @@
+const dataService = {
+  getAll: (key) => {
+    return new Promise((resolve) => {
+      const data = localStorage.getItem(key);
+      try {
+        const parsed = JSON.parse(data) || [];
+        resolve(parsed);
+      } catch(e) {
+        resolve([]);
+      }
+    });
+  }
+};

--- a/js/views/amfe.js
+++ b/js/views/amfe.js
@@ -1,0 +1,49 @@
+function renderSimpleTable(containerId, rows) {
+  const container = document.getElementById(containerId);
+  container.innerHTML = '';
+  const table = document.createElement('table');
+  if (!rows.length) {
+    container.appendChild(document.createTextNode('No data'));
+    return;
+  }
+  const headers = Object.keys(rows[0]);
+  const thead = document.createElement('thead');
+  const trHead = document.createElement('tr');
+  headers.forEach(h => {
+    const th = document.createElement('th');
+    th.textContent = h;
+    trHead.appendChild(th);
+  });
+  thead.appendChild(trHead);
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+  rows.forEach(r => {
+    const tr = document.createElement('tr');
+    headers.forEach(h => {
+      const td = document.createElement('td');
+      td.textContent = r[h];
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  container.appendChild(table);
+}
+
+function renderAMFE(rows) {
+  renderSimpleTable('amfe', rows);
+}
+
+function loadData() {
+  document.getElementById('loading').style.display = 'block';
+  dataService.getAll('amfe').then(rows => {
+    renderAMFE(rows);
+  }).finally(() => {
+    document.getElementById('loading').style.display = 'none';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('refresh').addEventListener('click', loadData);
+  loadData();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,26 @@
+#loading { display: none; }
+
+.table-container {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+thead {
+  background: #f0f0f0;
+  position: sticky;
+  top: 0;
+}
+
+tr:nth-child(even) {
+  background: #f9f9f9;
+}
+
+td, th {
+  padding: 8px;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- build a minimal AMFE view page
- load data from `localStorage` and render a table
- style table with zebra stripes
- document how to use the page

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d944f1fc8832fa765b4c32bba2c88