### PR TITLE
Add default AMFE data when none present

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Esta versión incluye una vista sencilla de AMFE.
 
 1. Abre `index.html` (o `amfe.html`) en un navegador.
 2. La página leerá los datos almacenados en `localStorage` bajo la clave `amfe`.
+   Si no existe ningún valor para esa clave, se cargará automáticamente un juego de datos de ejemplo y se guardará en tu navegador.
 3. Se mostrará un spinner mientras se cargan los datos.
 4. La tabla resultante es solo de lectura y puede refrescarse con el botón **Refrescar**.
 
-Los datos deben estar almacenados como un array de objetos JSON. Ejemplo:
+Si quieres definir tus propios registros, puedes sobrescribir los de ejemplo con el siguiente comando en la consola del navegador:
 ```javascript
 localStorage.setItem('amfe', JSON.stringify([
-  {"ID":1,"Item":"pieza","ModoFalla":"rotura"},
-  {"ID":2,"Item":"pieza2","ModoFalla":"desgaste"}
+  { ID: 1, Item: 'pieza',  ModoFalla: 'rotura' },
+  { ID: 2, Item: 'pieza2', ModoFalla: 'desgaste' }
 ]));
 ```

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -1,11 +1,22 @@
+const DEFAULT_DATA = {
+  amfe: [
+    { ID: 1, Item: "pieza", ModoFalla: "rotura" },
+    { ID: 2, Item: "pieza2", ModoFalla: "desgaste" }
+  ]
+};
+
 const dataService = {
   getAll: (key) => {
     return new Promise((resolve) => {
-      const data = localStorage.getItem(key);
+      let data = localStorage.getItem(key);
+      if (!data && DEFAULT_DATA[key]) {
+        localStorage.setItem(key, JSON.stringify(DEFAULT_DATA[key]));
+        data = JSON.stringify(DEFAULT_DATA[key]);
+      }
       try {
         const parsed = JSON.parse(data) || [];
         resolve(parsed);
-      } catch(e) {
+      } catch (e) {
         resolve([]);
       }
     });


### PR DESCRIPTION
## Summary
- auto-populate AMFE table with example data if no entry exists in localStorage
- document the new default dataset behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d98683c40832fb7049437cd7be842