### PR TITLE
Fix default data recovery on JSON parse errors

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -17,7 +17,12 @@ const dataService = {
         const parsed = JSON.parse(data) || [];
         resolve(parsed);
       } catch (e) {
-        resolve([]);
+        if (e instanceof SyntaxError && DEFAULT_DATA[key]) {
+          localStorage.setItem(key, JSON.stringify(DEFAULT_DATA[key]));
+          resolve(DEFAULT_DATA[key]);
+        } else {
+          resolve([]);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure corrupted `localStorage` values fall back to defaults

## Testing
- `node -e "require('./js/dataService.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684d9ac18aa4832fb80c1f45ca033898