### PR TITLE
Improve CSS for mobile and dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,26 +1,81 @@
 #loading { display: none; }
 
+:root {
+  --background: #ffffff;
+  --text-color: #000000;
+  --header-bg: #f0f0f0;
+  --row-even-bg: #f9f9f9;
+  --border-color: #ccc;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1b1b1b;
+    --text-color: #e0e0e0;
+    --header-bg: #333333;
+    --row-even-bg: #2a2a2a;
+    --border-color: #555555;
+  }
+}
+
+
 .table-container {
   max-height: 400px;
   overflow-y: auto;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 table {
   border-collapse: collapse;
   width: 100%;
+  min-width: 600px;
 }
 
 thead {
-  background: #f0f0f0;
+  background: var(--header-bg);
   position: sticky;
   top: 0;
 }
 
 tr:nth-child(even) {
-  background: #f9f9f9;
+  background: var(--row-even-bg);
 }
 
 td, th {
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
+}
+
+body {
+  background: var(--background);
+  color: var(--text-color);
+  margin: 1em;
+  font-family: Arial, sans-serif;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+@media (max-width: 600px) {
+  body {
+    font-size: 14px;
+    margin: 0.5em;
+  }
+
+  h1 {
+    font-size: 1.5em;
+    margin-bottom: 0.5em;
+  }
+
+  button {
+    font-size: 1em;
+    padding: 0.4em 0.6em;
+  }
+
+  td,
+  th {
+    padding: 6px;
+  }
 }


### PR DESCRIPTION
## Summary
- refine table layout for small screens and enable horizontal scrolling
- support light and dark modes using CSS variables
- adjust font sizes and margins via media queries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9cc58bec832f90901542774bc893