### PR TITLE
Add CSV export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Esta versión incluye una vista sencilla de AMFE.
    Si no existe ningún valor para esa clave, se cargará automáticamente un juego de datos de ejemplo y se guardará en tu navegador.
 3. Se mostrará un spinner mientras se cargan los datos.
 4. La tabla resultante es solo de lectura y puede refrescarse con el botón **Refrescar**.
+5. Los datos visibles pueden descargarse en CSV con el botón **Exportar**.
 
 Si quieres definir tus propios registros, puedes sobrescribir los de ejemplo con el siguiente comando en la consola del navegador:
 ```javascript

--- a/amfe.html
+++ b/amfe.html
@@ -8,6 +8,7 @@
 <body>
 <h1>AMFE</h1>
 <button id="refresh">Refrescar</button>
+<button id="export">Exportar</button>
 <div id="loading">Cargando...</div>
 <div id="amfe" class="table-container"></div>
 <script src="js/dataService.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <body>
 <h1>AMFE</h1>
 <button id="refresh">Refrescar</button>
+<button id="export">Exportar</button>
 <div id="loading">Cargando...</div>
 <div id="amfe" class="table-container"></div>
 <script src="js/dataService.js"></script>

--- a/js/views/amfe.js
+++ b/js/views/amfe.js
@@ -34,6 +34,27 @@ function renderAMFE(rows) {
   renderSimpleTable('amfe', rows);
 }
 
+function exportTable() {
+  const table = document.querySelector('#amfe table');
+  if (!table) return;
+  const headers = Array.from(table.querySelectorAll('thead th')).map(th => th.textContent);
+  const rows = Array.from(table.querySelectorAll('tbody tr')).map(tr =>
+    Array.from(tr.querySelectorAll('td')).map(td => td.textContent)
+  );
+  const csvRows = [headers, ...rows].map(r =>
+    r.map(field => '"' + String(field).replace(/"/g, '""') + '"').join(',')
+  ).join('\n');
+  const blob = new Blob([csvRows], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'amfe.csv';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
 function loadData() {
   document.getElementById('loading').style.display = 'block';
   dataService.getAll('amfe').then(rows => {
@@ -45,5 +66,9 @@ function loadData() {
 
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('refresh').addEventListener('click', loadData);
+  const exportBtn = document.getElementById('export');
+  if (exportBtn) {
+    exportBtn.addEventListener('click', exportTable);
+  }
   loadData();
 });


### PR DESCRIPTION
## Summary
- enable exporting the visible table rows to CSV
- add Exportar button to the HTML views
- document the new feature in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d9cc2d248832f90de6a9c39d0888d