### PR TITLE
Integrate cover page into main view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BarackV2
 
 Esta versión incluye una vista sencilla de AMFE.
-También se incluye `cover.html`, que es la carátula del AMFE y puede abrirse directamente o mediante el enlace disponible en `index.html`.
+La carátula del AMFE ahora se muestra en la parte superior de `index.html`, aunque sigue disponible como página independiente en `cover.html`.
 
 ## Uso
 

--- a/index.html
+++ b/index.html
@@ -6,14 +6,31 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<h1>AMFE</h1>
-<a href="cover.html" class="cover-link">Ver carátula</a>
-<button id="refresh">Refrescar</button>
-<button id="export">Exportar CSV</button>
-<input type="text" id="filter" placeholder="Filtrar..." aria-label="Filtrar">
-<div id="loading" role="status" aria-live="polite">Cargando...</div>
-<div id="amfe" class="table-container"></div>
-<script src="js/dataService.js"></script>
-<script src="js/views/amfe.js"></script>
+  <div class="cover-container">
+    <h1>AMFE de proceso general</h1>
+    <p><strong>Nombre de la organización:</strong> Brack</p>
+    <p><strong>Localización de la planta:</strong> Planta Hurlingham</p>
+    <p><strong>Tema:</strong> AMFE general</p>
+    <p><strong>Fecha de creación:</strong> 14/06/2025</p>
+    <p><strong>Fecha de revisión:</strong> </p>
+    <p><strong>Responsable del diseño:</strong> Facundo Santoro</p>
+    <p><strong>Nivel de confidencialidad:</strong> </p>
+    <div class="section">
+      <h2>Equipo multifuncional</h2>
+      <p>Paulo Centurión – Ingeniería</p>
+      <p>Marcelo Nieve – Calidad</p>
+      <p>Cristina Rabago – Seguridad e higiene</p>
+      <p>Leonardo Lattanzi – Producción</p>
+    </div>
+  </div>
+
+  <h2>AMFE</h2>
+  <button id="refresh">Refrescar</button>
+  <button id="export">Exportar CSV</button>
+  <input type="text" id="filter" placeholder="Filtrar..." aria-label="Filtrar">
+  <div id="loading" role="status" aria-live="polite">Cargando...</div>
+  <div id="amfe" class="table-container"></div>
+  <script src="js/dataService.js"></script>
+  <script src="js/views/amfe.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -25,20 +25,11 @@
 
 :root {
   --background: #ffffff;
-  --text-color: #000000;
-  --header-bg: #f0f0f0;
-  --row-even-bg: #f9f9f9;
+  --text-color: #333333;
+  --header-bg: #44546A;
+  --header-color: #ffffff;
+  --row-even-bg: #f0f4f8;
   --border-color: #ccc;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #1b1b1b;
-    --text-color: #e0e0e0;
-    --header-bg: #333333;
-    --row-even-bg: #2a2a2a;
-    --border-color: #555555;
-  }
 }
 
 
@@ -57,6 +48,7 @@ table {
 
 thead {
   background: var(--header-bg);
+  color: var(--header-color);
   position: sticky;
   top: 0;
 }
@@ -81,10 +73,6 @@ h1 {
   margin-top: 0;
 }
 
-.cover-link {
-  display: block;
-  margin-bottom: 1em;
-}
 
 @media (max-width: 600px) {
   body {


### PR DESCRIPTION
## Summary
- show the AMFE cover details directly on `index.html`
- simplify style and remove dark theme
- tweak header colours to use blue tones
- document the new placement of the cover page

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684da64e6030832fb895fa030720c4b5