### PR TITLE
Improve FMEA cover layout

### DIFF
--- a/cover.html
+++ b/cover.html
@@ -6,22 +6,37 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="cover">
-  <div class="cover-container">
-    <h1>AMFE de proceso general</h1>
-    <p><strong>Nombre de la organización:</strong> Brack</p>
-    <p><strong>Localización de la planta:</strong> Planta Hurlingham</p>
-    <p><strong>Tema:</strong> AMFE general</p>
-    <p><strong>Fecha de creación:</strong> 14/06/2025</p>
-    <p><strong>Fecha de revisión:</strong> </p>
-    <p><strong>Responsable del diseño:</strong> Facundo Santoro</p>
-    <p><strong>Nivel de confidencialidad:</strong> </p>
-    <div class="section">
-      <h2>Equipo multifuncional</h2>
-      <p>Paulo Centurión – Ingeniería</p>
-      <p>Marcelo Nieve – Calidad</p>
-      <p>Cristina Rabago – Seguridad e higiene</p>
-      <p>Leonardo Lattanzi – Producción</p>
-    </div>
-  </div>
+  <h1 class="fmea-title">AMFE-FMEA DE PROCESO</h1>
+  <table class="sheet">
+    <tr>
+      <th>NOMBRE DE LA ORGANIZACIÓN</th>
+      <td>BARACK</td>
+      <th>LOCALIZACIÓN DE LA PLANTA</th>
+      <td>PLANTA HURLINGHAM</td>
+      <th>TEMA</th>
+      <td>AMFE GENERAL</td>
+    </tr>
+    <tr>
+      <th>FECHA DE CREACIÓN</th>
+      <td>14/06/2025</td>
+      <th>FECHA DE REVISIÓN</th>
+      <td></td>
+      <th>RESPONSABLE DEL DISEÑO</th>
+      <td>FACUNDO SANTORO</td>
+    </tr>
+    <tr>
+      <th>NIVEL DE CONFIDENCIALIDAD</th>
+      <td colspan="5"></td>
+    </tr>
+    <tr>
+      <th>EQUIPO MULTIFUNCIONAL</th>
+      <td colspan="5">
+        Paulo Centurión – Ingeniería<br>
+        Marcelo Nieve – Calidad<br>
+        Cristina Rabago – Seguridad e higiene<br>
+        Leonardo Lattanzi – Producción
+      </td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,23 +6,38 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="cover-container">
-    <h1>AMFE de proceso general</h1>
-    <p><strong>Nombre de la organización:</strong> Brack</p>
-    <p><strong>Localización de la planta:</strong> Planta Hurlingham</p>
-    <p><strong>Tema:</strong> AMFE general</p>
-    <p><strong>Fecha de creación:</strong> 14/06/2025</p>
-    <p><strong>Fecha de revisión:</strong> </p>
-    <p><strong>Responsable del diseño:</strong> Facundo Santoro</p>
-    <p><strong>Nivel de confidencialidad:</strong> </p>
-    <div class="section">
-      <h2>Equipo multifuncional</h2>
-      <p>Paulo Centurión – Ingeniería</p>
-      <p>Marcelo Nieve – Calidad</p>
-      <p>Cristina Rabago – Seguridad e higiene</p>
-      <p>Leonardo Lattanzi – Producción</p>
-    </div>
-  </div>
+  <h1 class="fmea-title">AMFE-FMEA DE PROCESO</h1>
+  <table class="sheet">
+    <tr>
+      <th>NOMBRE DE LA ORGANIZACIÓN</th>
+      <td>BARACK</td>
+      <th>LOCALIZACIÓN DE LA PLANTA</th>
+      <td>PLANTA HURLINGHAM</td>
+      <th>TEMA</th>
+      <td>AMFE GENERAL</td>
+    </tr>
+    <tr>
+      <th>FECHA DE CREACIÓN</th>
+      <td>14/06/2025</td>
+      <th>FECHA DE REVISIÓN</th>
+      <td></td>
+      <th>RESPONSABLE DEL DISEÑO</th>
+      <td>FACUNDO SANTORO</td>
+    </tr>
+    <tr>
+      <th>NIVEL DE CONFIDENCIALIDAD</th>
+      <td colspan="5"></td>
+    </tr>
+    <tr>
+      <th>EQUIPO MULTIFUNCIONAL</th>
+      <td colspan="5">
+        Paulo Centurión – Ingeniería<br>
+        Marcelo Nieve – Calidad<br>
+        Cristina Rabago – Seguridad e higiene<br>
+        Leonardo Lattanzi – Producción
+      </td>
+    </tr>
+  </table>
 
   <h2>AMFE</h2>
   <button id="refresh">Refrescar</button>

--- a/style.css
+++ b/style.css
@@ -124,3 +124,36 @@ body.cover {
 .cover-container p {
   margin: 0.3em 0;
 }
+
+/* FMEA cover table */
+.fmea-title {
+  background: var(--header-bg);
+  color: var(--header-color);
+  text-align: center;
+  padding: 10px;
+  margin: 0 0 20px 0;
+}
+
+table.sheet {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+  font-family: Arial, sans-serif;
+}
+
+table.sheet th,
+table.sheet td {
+  border: 1px solid var(--border-color);
+  padding: 8px;
+  vertical-align: top;
+}
+
+table.sheet th {
+  background: #f7f7f7;
+  text-transform: uppercase;
+  font-weight: normal;
+}
+
+table.sheet td {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- design FMEA cover header like spreadsheet
- apply same structured layout to index page
- style the FMEA header and table

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684da8ee40b8832f9c20ca68fee00cf3